### PR TITLE
Add 1.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "aiosignal" %}
 {% set version = "1.2.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,13 +11,14 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
     - frozenlist >=1.1.0
     - python >=3.6
@@ -26,16 +26,20 @@ requirements:
 test:
   imports:
     - aiosignal
-  commands:
-    - pip check
   requires:
     - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/aio-libs/aiosignal
   summary: 'aiosignal: a list of registered asynchronous callbacks'
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  dev_url: https://github.com/aio-libs/aiosignal
+  doc_url: https://aiosignal.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Add aiosignal 1.2.0 

Bug Tracker: new open issues https://github.com/aio-libs/aiosignal/issues
Github releases:  https://github.com/aio-libs/aiosignal/releases
Upstream license:  License file:  https://github.com/aio-libs/aiosignal/blob/master/LICENSE
Upstream Changelog: https://github.com/aio-libs/aiosignal/blob/v1.2.0/CHANGES.rst
Upstream setup file: https://github.com/aio-libs/aiosignal/blob/v1.2.0/setup.py

Actions: 

1. Update dependencies
2. Skip py<36
3. Add license_family, dev, doc urls
4. Add python <3.10 in test