### PR TITLE
update to 1.4.0 and add tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,12 @@ requirements:
   host:
     - pip
     - python
+    - setuptools >=51.0
     - wheel
   run:
     - frozenlist >=1.1.0
     - python
+    - typing-extensions >=4.2 # [py<313]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-asyncio
     - pytest-cov
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "aiosignal" %}
-{% set version = "1.2.0" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiosignal-{{ version }}.tar.gz
-  sha256: 78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aiosignal-{{ version }}.tar.gz
+  sha256: f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: true  # [py<37]
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -21,20 +21,24 @@ requirements:
     - python
   run:
     - frozenlist >=1.1.0
-    - python >=3.6
+    - python
 
 test:
+  source_files:
+    - tests
   imports:
     - aiosignal
   requires:
     - pip
-    - python <3.10
+    - pytest
+    - pytest-cov
   commands:
     - pip check
+    - pytest -v tests/
 
 about:
   home: https://github.com/aio-libs/aiosignal
-  summary: 'aiosignal: a list of registered asynchronous callbacks'
+  summary: "aiosignal: a list of registered asynchronous callbacks"
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: true  # [py<37]
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -43,6 +42,7 @@ test:
 about:
   home: https://github.com/aio-libs/aiosignal
   summary: "aiosignal: a list of registered asynchronous callbacks"
+  description: "aiosignal: a list of registered asynchronous callbacks"
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - pip
     - python
+    - wheel
   run:
     - frozenlist >=1.1.0
     - python
@@ -35,7 +36,7 @@ test:
     - pytest-cov
   commands:
     - pip check
-    - pytest -v tests/
+    - pytest -v tests/ --asyncio-mode=auto
 
 about:
   home: https://github.com/aio-libs/aiosignal


### PR DESCRIPTION
aiosignal 1.4.0

**Destination channel:** defaults

### Links

- [PKG-9290](https://anaconda.atlassian.net/browse/PKG-9290) 
- [Upstream repository](https://github.com/aio-libs/aiosignal)
- [Upstream changelog/diff](https://github.com/aio-libs/aiosignal/compare/v1.3.1...v1.4.0)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- async tests added. Version bump


[PKG-9290]: https://anaconda.atlassian.net/browse/PKG-9290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ